### PR TITLE
fixing html commands serverside

### DIFF
--- a/Chatroom Project/src/server/Room.java
+++ b/Chatroom Project/src/server/Room.java
@@ -17,9 +17,11 @@ public class Room implements AutoCloseable {
 	private final static String COMMAND_TRIGGER = "/";
 	private final static String CREATE_ROOM = "createroom";
 	private final static String JOIN_ROOM = "joinroom";
-	// adding commands for flip and roll
+	// adding commands for flip, roll, and html
 	private final static String FLIP = "flip";
 	private final static String ROLL = "roll";
+	private final static String HTML = "html";
+	private final static String COLOR = "color";
 
 	public Room(String name) {
 		this.name = name;
@@ -138,6 +140,37 @@ public class Room implements AutoCloseable {
 					Random random2 = new Random();
 					int index2 = random2.nextInt(coin.length);
 					sendCommand(client, "flipped " + coin[index2]);
+					wasCommand = true;
+					break;
+				// adding html command
+				case HTML:
+					String erased = message.replaceAll("/html", "");
+					// replacing b tags here for bold
+					erased = erased.replaceAll("!b", "<b>");
+					erased = erased.replaceAll("/b", "</b>");
+					// replacing u tags for underline
+					erased = erased.replaceAll("!u", "<u>");
+					erased = erased.replaceAll("/u", "</u>");
+					// replacing i tags for italicize
+					erased = erased.replaceAll("!i", "<i>");
+					erased = erased.replaceAll("/i", "</i>");
+					sendCommand(client, erased);
+					wasCommand = true;
+					break;
+				case COLOR:
+					String fontColor = comm2[1];
+					String eraseCommand = message.replaceAll("/color " + fontColor, "");
+					eraseCommand = eraseCommand.replaceAll("!c", "<font color= " + "\"" + fontColor + "\"" + ">");
+					eraseCommand = eraseCommand.replaceAll("/c", "</font>");
+					eraseCommand = eraseCommand.replaceAll("!b", "<b>");
+					eraseCommand = eraseCommand.replaceAll("/b", "</b>");
+					// replacing u tags for underline
+					eraseCommand = eraseCommand.replaceAll("!u", "<u>");
+					eraseCommand = eraseCommand.replaceAll("/u", "</u>");
+					// replacing i tags for italicize
+					eraseCommand = eraseCommand.replaceAll("!i", "<i>");
+					eraseCommand = eraseCommand.replaceAll("/i", "</i>");
+					sendCommand(client, eraseCommand);
 					wasCommand = true;
 					break;
 				}


### PR DESCRIPTION
adding server-side commands to the html

fixing a feature from milestone 2:

Create a server side function that processes messages to change text display that’s broadcasted to all clients (for this milestone just show the altered text symbols, we won’t be able to see the effects until Milestone 3)
Bold
Italics
Color
Underline

Custom text display functions appear correctly in the chat area
completed when implemented HTML in jeditorpane

![image](https://user-images.githubusercontent.com/60161203/99592986-f6701e00-29be-11eb-86d2-0ad270c8e57a.png)

Also added /commands for the user

/html
You would use the command like this
/html !bbold/b !uunderline/u !iitalicize/i
Bold
!b for opening and /b for closing
Underline
!u for opening and /u for closing
Italicize
!i for opening and /i for closing

/color
You would use the command like this if you want color along with the html
/color red !c!bbold/b/c !uunderline/u !iitalicize/i
You type /color followed by the color and then use
!c for opening and /c for closing
The other html tags are also here
I just wanted a separate command so I could take the string after command (the color) 
Note that you can omit the closing tags so that the text after the opening tag is all affected
/html !bbold !uunderline/u !iitalicize/i
