### PR TITLE
adding different format for flip and roll commands

### DIFF
--- a/Chatroom Project/src/server/Room.java
+++ b/Chatroom Project/src/server/Room.java
@@ -131,7 +131,7 @@ public class Room implements AutoCloseable {
 					String[] dice = new String[] { "1", "2", "3", "4", "5", "6" };
 					Random random = new Random();
 					int index = random.nextInt(dice.length);
-					sendCommand(client, "rolled " + dice[index]);
+					sendCommand(client, "<b>rolled " + "<font color=\"red\">" + dice[index] + "</font></b>");
 					wasCommand = true;
 					break;
 				// adding /flip command
@@ -139,7 +139,7 @@ public class Room implements AutoCloseable {
 					String[] coin = new String[] { "heads", "tails" };
 					Random random2 = new Random();
 					int index2 = random2.nextInt(coin.length);
-					sendCommand(client, "flipped " + coin[index2]);
+					sendCommand(client, "<b>flipped " + "<font color=\"red\">" + coin[index2] + "</font></b>");
 					wasCommand = true;
 					break;
 				// adding html command


### PR DESCRIPTION
Results from /flip and /roll appear in a different format than regular chat text

![image](https://user-images.githubusercontent.com/60161203/100475889-3d8e9b00-30b2-11eb-8668-64c66d8f63dc.png)

implemented HTML to the roll and flip command messages to highlight commands and contrast from regular text