### PR TITLE
Feature @username

### DIFF
--- a/Chatroom Project/src/server/Room.java
+++ b/Chatroom Project/src/server/Room.java
@@ -17,11 +17,12 @@ public class Room implements AutoCloseable {
 	private final static String COMMAND_TRIGGER = "/";
 	private final static String CREATE_ROOM = "createroom";
 	private final static String JOIN_ROOM = "joinroom";
-	// adding commands for flip, roll, and html
+	// adding commands for flip, roll, @, and html
 	private final static String FLIP = "flip";
 	private final static String ROLL = "roll";
 	private final static String HTML = "html";
 	private final static String COLOR = "color";
+	private final static String AT_SIGN = "@";
 
 	public Room(String name) {
 		this.name = name;
@@ -160,8 +161,9 @@ public class Room implements AutoCloseable {
 				case COLOR:
 					String fontColor = comm2[1];
 					String eraseCommand = message.replaceAll("/color " + fontColor, "");
-					eraseCommand = eraseCommand.replaceAll("!c", "<font color= " + "\"" + fontColor + "\"" + ">");
+					eraseCommand = eraseCommand.replaceAll("!c", "<font color=" + "\"" + fontColor + "\"" + ">");
 					eraseCommand = eraseCommand.replaceAll("/c", "</font>");
+					// replacing b tags for bold
 					eraseCommand = eraseCommand.replaceAll("!b", "<b>");
 					eraseCommand = eraseCommand.replaceAll("/b", "</b>");
 					// replacing u tags for underline
@@ -171,6 +173,12 @@ public class Room implements AutoCloseable {
 					eraseCommand = eraseCommand.replaceAll("!i", "<i>");
 					eraseCommand = eraseCommand.replaceAll("/i", "</i>");
 					sendCommand(client, eraseCommand);
+					wasCommand = true;
+					break;
+				case AT_SIGN:
+					String uName = comm2[1];
+					String deleteAT = message.replaceAll("@ " + uName, "");
+					sendPrivate(client, uName, deleteAT);
 					wasCommand = true;
 					break;
 				}
@@ -200,6 +208,17 @@ public class Room implements AutoCloseable {
 		while (iter.hasNext()) {
 			ServerThread c = iter.next();
 			c.send(client.getClientName(), message);
+		}
+	}
+
+	// creating a function for privately sending messages to a user
+	protected void sendPrivate(ServerThread client, String recipient, String message) {
+		Iterator<ServerThread> iter = clients.iterator();
+		while (iter.hasNext()) {
+			ServerThread c = iter.next();
+			if (c.toString() == recipient) {
+				c.send(client.getClientName(), message);
+			}
 		}
 	}
 

--- a/Chatroom Project/src/server/Room.java
+++ b/Chatroom Project/src/server/Room.java
@@ -22,7 +22,7 @@ public class Room implements AutoCloseable {
 	private final static String ROLL = "roll";
 	private final static String HTML = "html";
 	private final static String COLOR = "color";
-	private final static String AT_SIGN = "@";
+	private final static String AT = "@";
 
 	public Room(String name) {
 		this.name = name;
@@ -132,7 +132,7 @@ public class Room implements AutoCloseable {
 					String[] dice = new String[] { "1", "2", "3", "4", "5", "6" };
 					Random random = new Random();
 					int index = random.nextInt(dice.length);
-					sendCommand(client, "rolled " + dice[index]);
+					sendCommand(client, "<b>rolled " + "<font color=\"red\">" + dice[index] + "</font></b>");
 					wasCommand = true;
 					break;
 				// adding /flip command
@@ -140,7 +140,7 @@ public class Room implements AutoCloseable {
 					String[] coin = new String[] { "heads", "tails" };
 					Random random2 = new Random();
 					int index2 = random2.nextInt(coin.length);
-					sendCommand(client, "flipped " + coin[index2]);
+					sendCommand(client, "<b>flipped " + "<font color=\"red\">" + coin[index2] + "</font></b>");
 					wasCommand = true;
 					break;
 				// adding html command
@@ -175,14 +175,29 @@ public class Room implements AutoCloseable {
 					sendCommand(client, eraseCommand);
 					wasCommand = true;
 					break;
-				case AT_SIGN:
-					String uName = comm2[1];
-					String deleteAT = message.replaceAll("@ " + uName, "");
-					sendPrivate(client, uName, deleteAT);
-					wasCommand = true;
-					break;
+				/*
+				 * @username private message command experiment case AT_SIGN: String uName =
+				 * comm2[1]; String deleteAT = message.replaceAll("/dm " + uName, "");
+				 * sendPrivate(client, uName, deleteAT); wasCommand = true; break;
+				 */
 				}
 			}
+
+			// added @user message private dm feature here
+			if (message.indexOf(AT) > -1) {
+				String[] trigger = message.split(AT);
+				log.log(Level.INFO, message);
+				String part1 = trigger[1];
+				String[] comm2 = part1.split(" ");
+				String uName = comm2[0];
+				if (uName != null) {
+					uName = uName.toLowerCase();
+				}
+				String delUName = message.replaceAll("@" + uName, "");
+				sendPrivate(client, uName, delUName);
+				wasCommand = true;
+			}
+
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -216,7 +231,7 @@ public class Room implements AutoCloseable {
 		Iterator<ServerThread> iter = clients.iterator();
 		while (iter.hasNext()) {
 			ServerThread c = iter.next();
-			if (c.toString() == recipient) {
+			if (c.getClientName().equals(recipient) || c.getClientName() == client.getClientName()) {
 				c.send(client.getClientName(), message);
 			}
 		}


### PR DESCRIPTION
Closing a feature from Milestone 3:

Messages that precede with @username will send the message privately to the user denoted by the username
The writer and the receiver are the only two that will receive the message from the server
It’s not valid to just hide it on the client-side (i.e., data must not be sent from the server)

![image](https://user-images.githubusercontent.com/60161203/100523251-12bd4900-317d-11eb-965f-37dd983695db.png)

Implemented private direct messages by using the @username format
For example: in the picture I used: @bot middle cannot see this
typing a message with @[username] will privately send the message to the recipient's client and the origin's console

