### PR TITLE
adding mute feature and a little extra

### DIFF
--- a/Chatroom Project/src/client/ClientUI.java
+++ b/Chatroom Project/src/client/ClientUI.java
@@ -106,6 +106,8 @@ public class ClientUI extends JFrame implements Event {
 				String name = username.getText();
 				if (name != null && name.length() > 0) {
 					SocketClient.setUsername(name);
+					// trying to change the title of the window to better show who's console it is
+					self.setTitle(self.getTitle() + " - " + name);
 					self.next();
 				}
 			}
@@ -294,7 +296,7 @@ public class ClientUI extends JFrame implements Event {
 	}
 
 	public static void main(String[] args) {
-		ClientUI ui = new ClientUI("My UI");
+		ClientUI ui = new ClientUI("Chatroom UI");
 		if (ui != null) {
 			log.log(Level.FINE, "Started");
 		}

--- a/Chatroom Project/src/server/Room.java
+++ b/Chatroom Project/src/server/Room.java
@@ -17,12 +17,14 @@ public class Room implements AutoCloseable {
 	private final static String COMMAND_TRIGGER = "/";
 	private final static String CREATE_ROOM = "createroom";
 	private final static String JOIN_ROOM = "joinroom";
-	// adding commands for flip, roll, @, and html
+	// adding commands for flip, roll, @, mute, unmute, and html
 	private final static String FLIP = "flip";
 	private final static String ROLL = "roll";
 	private final static String HTML = "html";
 	private final static String COLOR = "color";
 	private final static String AT = "@";
+	private final static String MUTE = "mute";
+	private final static String UNMUTE = "unmute";
 
 	public Room(String name) {
 		this.name = name;
@@ -175,6 +177,18 @@ public class Room implements AutoCloseable {
 					sendCommand(client, eraseCommand);
 					wasCommand = true;
 					break;
+				case MUTE:
+					String MUser = comm2[1];
+					client.mutedList.add(MUser);
+					// maybe add a notification that the user was muted
+					wasCommand = true;
+					break;
+				case UNMUTE:
+					String UMUser = comm2[1];
+					client.mutedList.remove(UMUser);
+					// maybe add a notification that the user was unmuted
+					wasCommand = true;
+					break;
 				/*
 				 * @username private message command experiment case AT_SIGN: String uName =
 				 * comm2[1]; String deleteAT = message.replaceAll("/dm " + uName, "");
@@ -254,10 +268,12 @@ public class Room implements AutoCloseable {
 		Iterator<ServerThread> iter = clients.iterator();
 		while (iter.hasNext()) {
 			ServerThread client = iter.next();
-			boolean messageSent = client.send(sender.getClientName(), message);
-			if (!messageSent) {
-				iter.remove();
-				log.log(Level.INFO, "Removed client " + client.getId());
+			if (!client.isMuted(sender.getClientName())) {
+				boolean messageSent = client.send(sender.getClientName(), message);
+				if (!messageSent) {
+					iter.remove();
+					log.log(Level.INFO, "Removed client " + client.getId());
+				}
 			}
 		}
 	}

--- a/Chatroom Project/src/server/ServerThread.java
+++ b/Chatroom Project/src/server/ServerThread.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -15,6 +17,11 @@ public class ServerThread extends Thread {
 	private Room currentRoom;// what room we are in, should be lobby by default
 	private String clientName;
 	private final static Logger log = Logger.getLogger(ServerThread.class.getName());
+	List<String> mutedList = new ArrayList<String>();
+
+	public boolean isMuted(String clientName) {
+		return mutedList.contains(clientName);
+	}
 
 	public String getClientName() {
 		return clientName;


### PR DESCRIPTION
closing a feature from milestone 3:

The following commands will be implemented
mute @username
Prevents the user from receiving messages from the denoted user
unmute @username
Allows the user to receive messages from the denoted user (if they were previously muted)

![image](https://user-images.githubusercontent.com/60161203/100765558-a2edcf00-33c5-11eb-88ae-548653473e53.png)

Top muted mid and top was unable to see the message “top muted”. Then top unmuted mid and was able to see the message “top unmuted me”.

NOTE: the server says sending message to 3 clients is not true. That line of code grabs the clients.size so it will grab the total number of clients regardless if it is sending it to that amount of clients. 
