### PR TITLE
adding mutestatus feature and fix for /mute command to use the correc…

### DIFF
--- a/Chatroom Project/src/server/Room.java
+++ b/Chatroom Project/src/server/Room.java
@@ -178,15 +178,25 @@ public class Room implements AutoCloseable {
 					wasCommand = true;
 					break;
 				case MUTE:
-					String MUser = comm2[1];
-					client.mutedList.add(MUser);
-					// maybe add a notification that the user was muted
+					String[] MUser = comm2[1].split(AT);
+					String MUser1 = MUser[1];
+					// added if statement to prevent duplicate issues
+					if (!client.mutedList.contains(MUser1)) {
+						client.mutedList.add(MUser1);
+					}
+					// add a notification that the user was muted
+					muteStatus(client, MUser1);
 					wasCommand = true;
 					break;
 				case UNMUTE:
-					String UMUser = comm2[1];
-					client.mutedList.remove(UMUser);
-					// maybe add a notification that the user was unmuted
+					String[] UMUser = comm2[1].split(AT);
+					String UMUser1 = UMUser[1];
+					// added if statement to prevent duplicate issues
+					if (client.mutedList.contains(UMUser1)) {
+						client.mutedList.remove(UMUser1);
+					}
+					// add a notification that the user was unmuted
+					unmuteStatus(client, UMUser1);
 					wasCommand = true;
 					break;
 				/*
@@ -198,7 +208,7 @@ public class Room implements AutoCloseable {
 			}
 
 			// added @user message private dm feature here
-			if (message.indexOf(AT) > -1) {
+			if (message.indexOf(AT) == 0) {
 				String[] trigger = message.split(AT);
 				log.log(Level.INFO, message);
 				String part1 = trigger[1];
@@ -247,6 +257,26 @@ public class Room implements AutoCloseable {
 			ServerThread c = iter.next();
 			if (c.getClientName().equals(recipient) || c.getClientName() == client.getClientName()) {
 				c.send(client.getClientName(), message);
+			}
+		}
+	}
+
+	protected void muteStatus(ServerThread client, String recipient) {
+		Iterator<ServerThread> iter = clients.iterator();
+		while (iter.hasNext()) {
+			ServerThread c = iter.next();
+			if (c.getClientName().equals(recipient)) {
+				c.send(client.getClientName(), "<b><i>has muted you</b></i>");
+			}
+		}
+	}
+
+	protected void unmuteStatus(ServerThread client, String recipient) {
+		Iterator<ServerThread> iter = clients.iterator();
+		while (iter.hasNext()) {
+			ServerThread c = iter.next();
+			if (c.getClientName().equals(recipient)) {
+				c.send(client.getClientName(), "<b><i>has unmuted you</b></i>");
 			}
 		}
 	}


### PR DESCRIPTION
…t format

closing a feature from milestone 4:

Clients will receive a message when they get muted/unmuted by another user
(i.e., Bob muted you)
This message should only be sent if muted becomes unmuted or unmuted becomes mute, it’s not an opportunity to create a spam mechanism

![image](https://user-images.githubusercontent.com/60161203/101235994-462b3680-369b-11eb-87df-ede544db3c84.png)

this shows the user that was muted/unmuted in bold and italics that the sender of the message muted/unmuted the user.
I also added a few fixes to the original /mute and /unmute commands

they are the following:

added an if statement that will only mute if the user is not muted (if they are not in the mutedList). 
added an if statement that will only unmute the user if the user is muted (if they are in the mutedList).

also fixed the old code to use the correct format. forgot to add the '@' that preceded the user name in this format: 
/mute @username