### PR TITLE
adding persistent mute list

### DIFF
--- a/Chatroom Project/src/server/Room.java
+++ b/Chatroom Project/src/server/Room.java
@@ -42,6 +42,7 @@ public class Room implements AutoCloseable {
 
 	protected synchronized void addClient(ServerThread client) {
 		client.setCurrentRoom(this);
+		client.loadMute();
 		if (clients.indexOf(client) > -1) {
 			log.log(Level.INFO, "Attempting to add a client that already exists");
 		} else {
@@ -186,6 +187,7 @@ public class Room implements AutoCloseable {
 					}
 					// add a notification that the user was muted
 					muteStatus(client, MUser1);
+					client.saveMutes();
 					wasCommand = true;
 					break;
 				case UNMUTE:
@@ -197,6 +199,7 @@ public class Room implements AutoCloseable {
 					}
 					// add a notification that the user was unmuted
 					unmuteStatus(client, UMUser1);
+					client.saveMutes();
 					wasCommand = true;
 					break;
 				/*

--- a/Chatroom Project/src/server/ServerThread.java
+++ b/Chatroom Project/src/server/ServerThread.java
@@ -1,11 +1,16 @@
 package server;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -19,6 +24,48 @@ public class ServerThread extends Thread {
 	private final static Logger log = Logger.getLogger(ServerThread.class.getName());
 	List<String> mutedList = new ArrayList<String>();
 
+	// adding saving mute list feature here
+	public void saveMutes() {
+		try (FileWriter fw = new FileWriter(getClientName() + "muteList.txt")) {
+			fw.write("" + getClientName() + ":");
+			Iterator<String> iter = mutedList.iterator();
+			while (iter.hasNext()) {
+				String m = iter.next();
+				fw.write(m + ",");
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	// adding loading mute list feature here
+	public void loadMute() {
+		File file = new File(getClientName() + "muteList.txt");
+		if (file.exists()) {
+			try (Scanner reader = new Scanner(file)) {
+				while (reader.hasNextLine()) {
+					String _user = reader.next();
+					String[] userLine = _user.split(":");
+					String user = userLine[0];
+					if (user.equals(getClientName())) {
+						String mutedUsers = userLine[1];
+						String[] muteArray = mutedUsers.split(",");
+						for (int i = 0; i < muteArray.length; i++) {
+							if (!mutedList.contains(muteArray[i])) {
+								mutedList.add(muteArray[i]);
+							}
+						}
+					}
+				}
+			} catch (FileNotFoundException e) {
+				e.printStackTrace();
+			} catch (Exception e2) {
+				e2.printStackTrace();
+			}
+		}
+	}
+
+	// added mute feature here
 	public boolean isMuted(String clientName) {
 		return mutedList.contains(clientName);
 	}


### PR DESCRIPTION
closing a feature from milestone 4:

Client’s mute list will persist across sessions
Based on username match

![image](https://user-images.githubusercontent.com/60161203/101424200-a0f5a580-38c8-11eb-98d3-ed22f00b5693.png)
![image](https://user-images.githubusercontent.com/60161203/101424203-a226d280-38c8-11eb-87dd-490b60492d61.png)

For each client there is a corresponding save file:
for example client named "top" would have a savefile called "topmuteList.txt"

on client connect:
client reads the save file([clientname]mutedList.txt) and loads the correspondent mutelist.

on client /mute or /unmute:
client writes to file ([clientname]mutedList.txt) for a future session to read that file and load the previous mutelist.